### PR TITLE
fix: reverted original enableExpressErrorHandler funcitonality

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -368,9 +368,7 @@ export function allowMethodOverride(req, res, next) {
 export function handleParseErrors(err, req, res, next) {
   const log = (req.config && req.config.loggerController) || defaultLogger;
   if (err instanceof Parse.Error) {
-    if (req.config && req.config.enableExpressErrorHandler) {
-      return next(err);
-    }
+
     let httpStatus;
     // TODO: fill out this mapping
     switch (err.code) {
@@ -386,6 +384,9 @@ export function handleParseErrors(err, req, res, next) {
     res.status(httpStatus);
     res.json({ code: err.code, error: err.message });
     log.error('Parse error: ', err);
+    if (req.config && req.config.enableExpressErrorHandler) {
+      next(err);
+    }
   } else if (err.status && err.message) {
     res.status(err.status);
     res.json({ error: err.message });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7859).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Reverts to the original behavior of enableExpressErrorHandler.
